### PR TITLE
Use relative URL for production environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:10.15
 
 ADD . /app
-RUN cd /app ; npm install ng ; npm run build-prod ; mv dist dist_prod ; npm run build ; mv dist dist_test
+RUN cd /app ; npm install ng ; npm run build-prod
 
 VOLUME /target
 
-CMD tar c -C /app/ dist_prod dist_test | tar x -C /target
+CMD tar c -C /app/dist/twitterwall . | tar x -C /target

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiURL: "https://www.devday.de/twitterwall/",
+  apiURL: "/twitterwall/",
 };


### PR DESCRIPTION
This changes the API URL for production environments to a host relative
URL. This works when the twitterwall application is served from the same
host (tested with a prod setup with changes in
https://github.com/devdaydresden/devday_website/pull/168 applied).